### PR TITLE
For training images with all 0 labels, change made in box_utils.hard_negative_mining.

### DIFF
--- a/vision/nn/multibox_loss.py
+++ b/vision/nn/multibox_loss.py
@@ -33,7 +33,7 @@ class MultiboxLoss(nn.Module):
             
         To accomodate for images with all 0 labels, change made in box_utils.hard_negative_mining.
 	    Idea is that 0 is considered only in classification loss, not in bbox regression loss.
-		A complete batch should contain atleat one positive label.
+		A batch should contain atleat one positive label.
         """
         num_classes = confidence.size(2)
         with torch.no_grad():

--- a/vision/nn/multibox_loss.py
+++ b/vision/nn/multibox_loss.py
@@ -30,6 +30,10 @@ class MultiboxLoss(nn.Module):
             locations (batch_size, num_priors, 4): predicted locations.
             labels (batch_size, num_priors): real labels of all the priors.
             boxes (batch_size, num_priors, 4): real boxes corresponding all the priors.
+            
+        To accomodate for images with all 0 labels, change made in box_utils.hard_negative_mining.
+	    Idea is that 0 is considered only in classification loss, not in bbox regression loss.
+		A complete batch should contain atleat one positive label.
         """
         num_classes = confidence.size(2)
         with torch.no_grad():

--- a/vision/utils/box_utils.py
+++ b/vision/utils/box_utils.py
@@ -192,9 +192,15 @@ def hard_negative_mining(loss, labels, neg_pos_ratio):
         loss (N, num_priors): the loss for each example.
         labels (N, num_priors): the labels.
         neg_pos_ratio:  the ratio between the negative examples and positive examples.
+    
     """
     pos_mask = labels > 0
     num_pos = pos_mask.long().sum(dim=1, keepdim=True)
+    
+    ## for training with images without any non zero labels
+    ## this will make sure 1*3(neg_pos_ratio) are added in the neg_mask, pos_mask will be empty
+    num_pos = torch.clamp(num_pos, min=1, max=1000000) # 1000000 : a very large number
+
     num_neg = num_pos * neg_pos_ratio
 
     loss[pos_mask] = -math.inf


### PR DESCRIPTION
Currently images with all 0 labels are not used in loss calculation. So change made in box_utils.hard_negative_mining to accommodate images with all 0 labels. The idea is that 0 is considered only in classification loss, not in bbox regression loss.
A batch should contain at least one positive label.