### PR TITLE
replace iteritems() with items()

### DIFF
--- a/open_images_downloader.py
+++ b/open_images_downloader.py
@@ -60,7 +60,7 @@ def http_download(url, path):
 
 
 def log_counts(values):
-    for k, count in values.value_counts().iteritems():
+    for k, count in values.value_counts().items():
         logging.warning(f"{k}: {count}/{len(values)} = {count/len(values):.2f}.")
 
 


### PR DESCRIPTION
Pandas throws an error now on iteritems 
  File "/opt/conda/envs/py311/lib/python3.11/site-packages/pandas/core/generic.py", line 6299, in __getattr__
    return object.__getattribute__(self, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Series' object has no attribute 'iteritems'
Needs to be updated with items()